### PR TITLE
Update Overlap Entity

### DIFF
--- a/calendar-api/src/main/java/com/study/calendar/api/ApiApplication.java
+++ b/calendar-api/src/main/java/com/study/calendar/api/ApiApplication.java
@@ -5,6 +5,7 @@ import com.study.calendar.core.SimpleEntityRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@EnableJpaAuditing
 @EntityScan("com.study.calendar.core")
 @EnableJpaRepositories("com.study.calendar.core")
 @RestController

--- a/calendar-core/src/main/java/com/study/calendar/core/domain/entity/BaseEntity.java
+++ b/calendar-core/src/main/java/com/study/calendar/core/domain/entity/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.study.calendar.core.domain.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public BaseEntity(Long id) {
+        this.id = id;
+    }
+}

--- a/calendar-core/src/main/java/com/study/calendar/core/domain/entity/Engagement.java
+++ b/calendar-core/src/main/java/com/study/calendar/core/domain/entity/Engagement.java
@@ -11,11 +11,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "engagements")
 @Entity
-public class Engagement {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Engagement extends BaseEntity {
 
     @JoinColumn(name = "schedule_id")
     @ManyToOne
@@ -24,7 +20,6 @@ public class Engagement {
     @JoinColumn(name = "attendee_id")
     @ManyToOne
     private User attendee;
-    private LocalDateTime createdAt = LocalDateTime.now();
     private RequestStatus requestStatus;
 
 }

--- a/calendar-core/src/main/java/com/study/calendar/core/domain/entity/Schedule.java
+++ b/calendar-core/src/main/java/com/study/calendar/core/domain/entity/Schedule.java
@@ -15,11 +15,7 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "schedules")
 @Entity
-public class Schedule {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+public class Schedule extends BaseEntity {
 
     private LocalDateTime startAt;
     private LocalDateTime endAt;
@@ -32,9 +28,6 @@ public class Schedule {
 
     @Enumerated(EnumType.STRING)
     private ScheduleType scheduleType;
-
-    @Builder.Default
-    private LocalDateTime createdAt = LocalDateTime.now();
 
     public static Schedule event(
             String title,

--- a/calendar-core/src/main/java/com/study/calendar/core/domain/entity/User.java
+++ b/calendar-core/src/main/java/com/study/calendar/core/domain/entity/User.java
@@ -11,17 +11,12 @@ import java.time.LocalDateTime;
 @Getter
 @Table(name = "users")
 @Entity
-public class User {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class User extends BaseEntity {
 
     private String name;
     private String email;
     private String password;
     private LocalDate birthday;
-    private LocalDateTime createAt = LocalDateTime.now();
 
     public User(String name, String email, String password, LocalDate birthday) {
         this.name = name;


### PR DESCRIPTION
* Long 타입의 id, 생성 시간, 수정 시간과 같은 공통적이고 중복되는 컬럼들을 `BaseEntity` 추상 클래스를 상속받아 단순화 및 중복 코드 제거.
* Jpa auditing을 사용하기 위해 `@EnableJpaAuditing` 추가